### PR TITLE
Added requirement for running on Windows Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ docker pull pintoch/openrefine-wikibase
 docker run pintoch/openrefine-wikibase
 ```
 
+On Windows you will need to expose the port so that get the Windows Firewall popup to accept on:
+```
+docker run -p 8000:8000 pintoch/openrefine-wikibase
+```
+
 Running manually
 ----------------
 


### PR DESCRIPTION
Without the explicit port mapping on the docker run command line, Windows 10 did allow connectivity across the bridge.  So trying in browser with http://localhost:8000 did not work with just `docker run pintoch/openrefine-wikibase`