### PR TITLE
Make the string search of the reconciliation service Wikidata-agnostic

### DIFF
--- a/config_wikidata.py
+++ b/config_wikidata.py
@@ -11,6 +11,12 @@ mediawiki_api_endpoint = 'https://www.wikidata.org/w/api.php'
 # SPARQL endpoint
 wikibase_sparql_endpoint = 'https://query.wikidata.org/sparql'
 
+# Wikibase namespace ID, used to search for items (default is 120, which is the default Wikibase 'Item:' namespace)
+wikibase_namespace_id = 120
+
+# Namespace prefix of Wikibase items (including colon, e.g. 'Item:')
+wikibase_namespace_prefix = ''
+
 # User agent to connect to the Wikidata APIs
 user_agent = 'OpenRefine-Wikidata reconciliation interface'
 

--- a/config_wikidata.py
+++ b/config_wikidata.py
@@ -11,8 +11,10 @@ mediawiki_api_endpoint = 'https://www.wikidata.org/w/api.php'
 # SPARQL endpoint
 wikibase_sparql_endpoint = 'https://query.wikidata.org/sparql'
 
-# Wikibase namespace ID, used to search for items (default is 120, which is the default Wikibase 'Item:' namespace)
-wikibase_namespace_id = 120
+# Wikibase namespace ID, used to search for items
+# For Wikidata this is 0, but most by default Wikibase uses 120, which is the default Wikibase 'Item:' namespace
+# CHANGE THIS TO 120 if you are adapting this configuration file to another Wikibase
+wikibase_namespace_id = 0
 
 # Namespace prefix of Wikibase items (including colon, e.g. 'Item:')
 wikibase_namespace_prefix = ''

--- a/wdreconcile/engine.py
+++ b/wdreconcile/engine.py
@@ -44,9 +44,9 @@ class ReconcileEngine(object):
             'srsearch':query_string,
             'srwhat':'text'},
             headers=config.headers)
-        resp = r.json()        
+        resp = r.json()
         # NOTE: remove the wikibase namespace prefix to only get the QID
-        search_results = [item['title'].split(config.wikibase_namespace_prefix,1)[1] for item in resp.get('query', {}).get('search', [])]
+        search_results = [item['title'][len(config.wikibase_namespace_prefix):] for item in resp.get('query', {}).get('search', [])]
         r = requests.get(
             config.mediawiki_api_endpoint,
             {'action':'wbsearchentities',
@@ -310,7 +310,7 @@ class ReconcileEngine(object):
 
         # sorting by inverse qid size for issue #26
         # we might want to replace that by something smarter like PageRank, but
-        # this is very cheap to compute 
+        # this is very cheap to compute
         # NOTE: remove the "Q" character explicitely (the previous method was not bullet-proof since there could be items with ID "Item:Qxxx" for instance)
         ranked_items = sorted(scored_items, key=lambda i: (-int(i.get('score', 0)), int(i['id'].split('Q',1)[1])))
 


### PR DESCRIPTION
- make namespace ID and prefix configurable
- tweak the way QIDs are processed (to make the reconciliation engine work with Wikibase instances other than Wikidata)

This PR is supposed to fix #67