### PR TITLE
Changed docker-compose volumes source to be ./config.py

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "8000:8000"
     volumes:
       - type: bind
-        source: ./config_docker.py
+        source: ./config.py
         target: /openrefine-wikibase/config.py
         read_only: true
   redis:


### PR DESCRIPTION
Making a small change in the docker-compose.yaml file to change the source in `volumes` from `./config-docker.py` to `./config.py` to match the README.